### PR TITLE
Static build: don't link SDL3main

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -233,7 +233,6 @@ fn link_sdl3(target_os: &str) {
         if cfg!(feature = "bundled")
             || (cfg!(feature = "use-pkgconfig") == false && cfg!(feature = "use-vcpkg") == false)
         {
-            println!("cargo:rustc-link-lib=static=SDL3main");
             if target_os.contains("windows") {
                 println!("cargo:rustc-link-lib=static=SDL3-static");
             } else {


### PR DESCRIPTION
AFAIK, `SDL3main` doesn't exist any more, and trying to link against it breaks my builds.

Note that this doesn't seem entirely sufficient to ensure working static builds on my setup; I will submit a separate issue shortly.